### PR TITLE
Update requirement version for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5.0"
+        "illuminate/support": "^5.0|^6.0"
     },
     "autoload": {
         "psr-4": {"Zofe\\Burp\\": "src/"}


### PR DESCRIPTION
If this would be merged, next PR would follow up to https://github.com/zofe/rapyd-laravel, as now it does not work with V6.